### PR TITLE
[fix](spark-load) remove conflict jar for spark_load of Doris v1.2

### DIFF
--- a/hive-shade-3/pom.xml
+++ b/hive-shade-3/pom.xml
@@ -98,6 +98,10 @@ under the License.
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-yarn-server-common</artifactId>
                 </exclusion>
+		<exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-yarn-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.hive/hive-storage-api -->


### PR DESCRIPTION
fix issue when submit a spark load job:
java.lang.VerifyError: Bad type on operand stack
Exception Details:
  Location:
    org/apache/hadoop/yarn/proto/YarnProtos$ApplicationReportProto$Builder.setClientToAmToken(Lorg/apache/hadoop/security/p
roto/SecurityProtos$TokenProto;)Lorg/apache/hadoop/yarn/proto/YarnProtos$ApplicationReportProto$Builder; @36: invokevirtual
  Reason:
    Type 'org/apache/hadoop/security/proto/SecurityProtos$TokenProto' (current frame, stack[1]) is not assignable to 'com/g
oogle/protobuf/GeneratedMessage'
  Current Frame:
    bci: @36
    flags: { }
    locals: { 'org/apache/hadoop/yarn/proto/YarnProtos$ApplicationReportProto$Builder', 'org/apache/hadoop/security/proto/SecurityProtos$TokenProto' }
    stack: { 'com/google/protobuf/SingleFieldBuilder', 'org/apache/hadoop/security/proto/SecurityProtos$TokenProto' }
  Bytecode:
    0x0000000: 2ab4 013f c700 1b2b c700 0bbb 0335 59b7
    0x0000010: 0336 bf2a 2bb5 00cc 2ab6 0214 a700 0c2a
    0x0000020: b401 3f2b b603 3a57 2a59 b401 3b10 4080
    0x0000030: b501 3b2a b0                           
  Stackmap Table:
    same_frame(@19)
    same_frame(@31)
    same_frame(@40)
