### PR TITLE
[Fix]add com.google.guava for broker(s3a scheme) 

### DIFF
--- a/hadoop-aws-shade-2/pom.xml
+++ b/hadoop-aws-shade-2/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.doris</groupId>
         <artifactId>doris-shade</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hadoop-aws-shade-2</artifactId>
@@ -36,6 +36,11 @@ under the License.
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-aws</artifactId>
             <version>${hadoop.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/hadoop-cloud-shade-2/pom.xml
+++ b/hadoop-cloud-shade-2/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.doris</groupId>
         <artifactId>doris-shade</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hadoop-cloud-shade-2</artifactId>

--- a/hadoop-shade-2/pom.xml
+++ b/hadoop-shade-2/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.doris</groupId>
         <artifactId>doris-shade</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hadoop-shade-2</artifactId>

--- a/hive-catalog-shade/pom.xml
+++ b/hive-catalog-shade/pom.xml
@@ -20,7 +20,7 @@ under the License.
     <parent>
         <groupId>org.apache.doris</groupId>
         <artifactId>doris-shade</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hive-catalog-shade</artifactId>

--- a/hive-shade-3/pom.xml
+++ b/hive-shade-3/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.doris</groupId>
         <artifactId>doris-shade</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hive-shade-3</artifactId>

--- a/hudi-mr-shade-0.13/pom.xml
+++ b/hudi-mr-shade-0.13/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.doris</groupId>
         <artifactId>doris-shade</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>hudi-mr-shade-0.13</artifactId>

--- a/kerby-shade-1.0/pom.xml
+++ b/kerby-shade-1.0/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.doris</groupId>
         <artifactId>doris-shade</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>kerby-shade-1.0</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@ under the License.
     </parent>
     <groupId>org.apache.doris</groupId>
     <artifactId>doris-shade</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Archetype - doris-shade</name>
     <url>https://doris.apache.org</url>

--- a/spring-shade-5/pom.xml
+++ b/spring-shade-5/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.doris</groupId>
         <artifactId>doris-shade</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-shade-5</artifactId>

--- a/thrift-shade-0.13/pom.xml
+++ b/thrift-shade-0.13/pom.xml
@@ -21,10 +21,10 @@ under the License.
     <parent>
         <groupId>org.apache.doris</groupId>
         <artifactId>doris-shade</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>1.0.3-SNAPSHOT</version>
     </parent>
     <artifactId>thrift-shade-0.13</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
     <properties>
         <libethrift.version>0.13.0</libethrift.version>
     </properties>


### PR DESCRIPTION
The S3AFileSystem class of broker contain  com.google.common.util.concurrent.ListeningExecutorService
its define in hadoop-aws-shade-2

[doris issue 26938](https://github.com/apache/doris/issues/26938)