### PR TITLE
upgrade hive-catalog-shade dependencies

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,16 +1,6 @@
 ## Changes
 
-### 2.0.0
-- upgrade avro to 1.11.3
-- upgrade parquet to 1.13.1
-- upgrade guava to 32.1.2-jre
-- upgrade gson to 2.10
-- upgrade bcprov to 1.70
-- upgrade paimon to 0.7.0
-- exclude some dependencies
+### 2.1.0
+- Upgrade paimon to 0.8.0
+- Upgrade bcpkix-jdkon15 dependency to bcpkix-jdkon18
 
-### 2.0.1
-- Set HikariCP Scope to Provided (#42)
-
-### 2.0.2
-- The com.aliyun.datalake package should not be renamed

--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,6 +1,21 @@
 ## Changes
 
-### 2.1.0
+### 2.1
+#### 2.1.0
 - Upgrade paimon to 0.8.0
 - Upgrade bcpkix-jdkon15 dependency to bcpkix-jdkon18
+### 2.0
+#### 2.0.0
+- upgrade avro to 1.11.3
+- upgrade parquet to 1.13.1
+- upgrade guava to 32.1.2-jre
+- upgrade gson to 2.10
+- upgrade bcprov to 1.70
+- upgrade paimon to 0.7.0
+- exclude some dependencies
 
+#### 2.0.1
+- Set HikariCP Scope to Provided (#42)
+
+#### 2.0.2
+- The com.aliyun.datalake package should not be renamed

--- a/hive-catalog-shade/pom.xml
+++ b/hive-catalog-shade/pom.xml
@@ -20,7 +20,7 @@ under the License.
     <parent>
         <groupId>org.apache.doris</groupId>
         <artifactId>doris-shade</artifactId>
-        <version>2.0.2-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>hive-catalog-shade</artifactId>
@@ -31,11 +31,11 @@ under the License.
         <hadoop.version>3.3.6</hadoop.version>
         <hive.storage.api.version>2.8.1</hive.storage.api.version>
         <iceberg-hive-metastore.version>1.4.3</iceberg-hive-metastore.version>
-        <paimon-hive-metastore.version>0.7.0-incubating</paimon-hive-metastore.version>
+        <paimon-hive-metastore.version>0.8.0</paimon-hive-metastore.version>
         <avro.version>1.11.3</avro.version>
         <ivy.version>2.5.2</ivy.version>
         <parquet.version>1.13.1</parquet.version>
-        <bcproy.version>1.70</bcproy.version>
+        <bcpkix.version>1.78.1</bcpkix.version>
         <guava.version>32.1.2-jre</guava.version>
         <gson.version>2.10</gson.version>
     </properties>
@@ -78,20 +78,11 @@ under the License.
                 <artifactId>parquet-hadoop-bundle</artifactId>
                 <version>${parquet.version}</version>
             </dependency>
-            <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on -->
-            <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on -->
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
-                <version>${bcproy.version}</version>
-            </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
             </dependency>
-
-            <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
@@ -545,6 +536,14 @@ under the License.
                 </exclusion>
             </exclusions>
         </dependency>
+        <!--should be provided in fe module-->
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>${bcpkix.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- for aliyun dlf -->
         <dependency>
             <groupId>com.aliyun.datalake</groupId>
@@ -562,6 +561,10 @@ under the License.
                 <exclusion>
                     <groupId>com.aliyun</groupId>
                     <artifactId>tea-util</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@ under the License.
     </parent>
     <groupId>org.apache.doris</groupId>
     <artifactId>doris-shade</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Archetype - doris-shade</name>
     <url>https://doris.apache.org</url>


### PR DESCRIPTION
## Changes
#### Upgrade paimon to 0.8.0
https://paimon.apache.org/releases/release-0.8/

#### Upgrade bcpkix-jdkon15 dependency to bcpkix-jdkon18

Since bcpkix-jdk15on is no longer being maintained and bcpkix-jdkon18 is fully compatible with it, we can replace bcpkix-jdk15on with bcpkix-jdkon18. This will ensure continued support and security for our applications.
FYI: https://www.bouncycastle.org/latest_releases.html

Considering that paimon 0.8 is a major version, I recommend that we release version 2.1 this time. 

